### PR TITLE
refactor: fix gatsby link

### DIFF
--- a/src/components/grid.tsx
+++ b/src/components/grid.tsx
@@ -11,7 +11,7 @@ type CardProps = {
 }
 
 const Card = ({ repo }: CardProps) => (
-  <Link to={repo.name} className={styles.cardWrap}>
+  <Link to={'/' + repo.name} className={styles.cardWrap}>
     <img
       alt=""
       className={styles.image}


### PR DESCRIPTION
Gatsby was giving a warning about this link – it needs the `/` at the beginning to understand it properly