### PR TITLE
refactor: improve grid link styles

### DIFF
--- a/src/components/grid.module.css
+++ b/src/components/grid.module.css
@@ -18,6 +18,14 @@
   }
 }
 
+.cardWrap,
+.cardWrap:hover,
+.cardWrap:focus,
+.cardWrap:active {
+  color: var(--fg);
+  text-decoration: none;
+}
+
 .cardWrap {
   border: 3px solid var(--gray);
   overflow: hidden;


### PR DESCRIPTION
This fixes a style bug introduced in #14

These CSS rules should not have been removed

## Before

<img width="1234" alt="Screen Shot 2020-04-13 at 21 08 48" src="https://user-images.githubusercontent.com/221614/79175182-02618500-7dcb-11ea-8043-3b6be38c815e.png">

## After

<img width="1232" alt="Screen Shot 2020-04-13 at 21 08 31" src="https://user-images.githubusercontent.com/221614/79175179-01305800-7dcb-11ea-98fd-d4bb669150ae.png">