### PR TITLE
Add TWZRD Agent Intel - MCP server for AI agent wallet trust scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Yet, we still recommend you use high-level programming languages to make your co
 | Package | Description |
 |---------|-------------|
 | [near-hydra](https://github.com/nikshepsvn/near-hydra) | All-in-one CLI + MCP server for Chain Signatures and NEAR Intents across 10 chains, built for AI agents |
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | MCP server for AI agent wallet trust scoring on Solana. Verify agent wallet identity before x402 micropayments. Free: `score_agent(wallet)`, `preflight_check(wallet)`. Config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}` |
 | [near-cli-rs](https://github.com/near/near-cli-rs) | Human-friendly interactive CLI for NEAR Protocol interactions |
 | [create-near-app](https://github.com/near/create-near-app) | Scaffold NEAR dApps with frontend and contract templates |
 | [cargo-near](https://github.com/near/cargo-near) | Cargo extension for building and deploying Rust smart contracts with ABI generation |


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **CLI Tools** section alongside `near-hydra` (another MCP server for AI agents).

TWZRD Agent Intel is an MCP server providing on-chain trust scoring for AI agent wallets. As NEAR AI agents and autonomous services execute cross-chain payments and interact with Agent Market escrow flows, verifying agent wallet identity becomes a key piece of the trust infrastructure.

**MCP Configuration:**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

**Free tools:**
- `score_agent(wallet)` — Trust score + on-chain reputation for any agent wallet
- `preflight_check(wallet)` — Validates agent wallet before payment acceptance

**Paid tool (x402 micropayment):**
- `get_trust_receipt(wallet)` — Verifiable signed trust receipt for agent identity