### PR TITLE
Add Edky to CLI Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Yet, we still recommend you use high-level programming languages to make your co
 | [cargo-near](https://github.com/near/cargo-near) | Cargo extension for building and deploying Rust smart contracts with ABI generation |
 | [near-validator-cli-rs](https://github.com/near/near-validator-cli-rs) | Human-friendly companion that helps to manage native NEAR stake and troubleshoot NEAR network |
 | [bos-cli-rs](https://github.com/bos-cli-rs/bos-cli-rs) | CLI that simplifies local component development for NEAR BOS |
+| [edky](https://github.com/artob/edky) | Convert Ed25519 public keys between various encoding formats (NEAR, iroh, libp2p, IPFS, OpenSSH, etc) |
 
 ---
 


### PR DESCRIPTION
**[Edky] converts Ed25519 public keys between various encoding formats, including NEAR's.**

```shellsession
$ cargo binstall -y edky

$ edky convert -f near -t hex ed25519:FVen3X669xLzsi6N2V91DoiyzHzg1uAgqiT8jZ9nS96Z
d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a

$ edky convert -f hex -t near d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a
ed25519:FVen3X669xLzsi6N2V91DoiyzHzg1uAgqiT8jZ9nS96Z
```

<img width="100%" alt="Showcase of edky convert" src="https://github.com/artob/edky/raw/master/rust/etc/asciinema/convert.gif"/>

[Edky]: https://github.com/artob/edky
