### PR TITLE
Add Testnet Faucets directory to Testnet Faucets section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ NOTE: If you are looking for the products built on NEAR, check out [NEAR Catalog
 |--------|-------------|
 | [Circle Faucet](https://faucet.circle.com/) | 20 USDC to be sent to NEAR Testnet (claimable every 2 hours) |
 | [NEAR Faucet](https://near-faucet.io/) | 2 NEAR on Testnet (always claimable, but rate limited) |
+| [Testnet Faucets](https://testnetfaucets.dev) | Directory of testnet faucets across 40+ networks, health-checked daily and verified on-chain; free JSON API |
 
 ---
 


### PR DESCRIPTION
Adds [Testnet Faucets](https://testnetfaucets.dev) to the Testnet Faucets section. It's a live, health-checked directory of testnet faucets across 40+ networks (including NEAR testnet) that verifies each dispensing wallet's balance and payout history on-chain daily, so developers can find a working faucet fast. It also exposes a free JSON API and a CI preflight tool. Entry follows the existing table format.